### PR TITLE
Validate url is using https

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,10 @@ func (payload *Payload) VerifyPayload() error {
 		return err
 	}
 
+	if certURL.Scheme != "https" {
+		return fmt.Errorf("url should be using https")
+	}
+
 	if !hostPattern.Match([]byte(certURL.Host)) {
 		return fmt.Errorf("certificate is located on an invalid domain")
 	}


### PR DESCRIPTION
Following recommendations from https://stackoverflow.com/questions/42662604/verifying-the-certificate-given-in-sns-message-signingcerturl and also directly from amazon https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html

![image](https://user-images.githubusercontent.com/6364887/108780148-e23b4000-751c-11eb-874a-52afe1cbae0a.png)
